### PR TITLE
YEL-1796

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -49,7 +49,7 @@ RUN sed -i '/#!\/usr\/bin\/python/c\#!\/usr\/bin\/python2.7' /usr/bin/yum && \
     sed -i '/#! \/usr\/bin\/python/c\#! \/usr\/bin\/python2.7' /usr/libexec/urlgrabber-ext-down
 
 # Install PM2
-RUN curl -sL https://rpm.nodesource.com/setup_11.x | bash - && \
+RUN curl -sL https://raw.githubusercontent.com/nodesource/distributions/master/rpm/setup_11.x -o setup_11.x && bash setup_11.x && rm setup_11.x && \
     yum install -y nodejs && \
     npm install -g pm2
 


### PR DESCRIPTION
pulling nodesource install script from github ("trusted source") and running bash after curl completes successfully

doesn't appear that nodesource sign the install script with a PGP key, so can't do a PGP-verified install